### PR TITLE
Update to import `addFetchListener` from ember-service-worker.

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,4 +1,6 @@
-self.addFetchListener(function(event) {
+import { addFetchListener } from 'ember-service-worker/service-worker';
+
+addFetchListener(function(event) {
   return caches.open('esw-fallback-cache')
     .then(function(cache) {
       return fetch(event.request, { mode: 'no-cors' })


### PR DESCRIPTION
This utilizes the changes made in
https://github.com/DockYard/ember-service-worker/pull/28, and is ready
to land and release once a version of ember-service-worker has been
released.
