### PR TITLE
Send credentials to same-origin

### DIFF
--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -6,7 +6,7 @@ const CACHE_NAME = `${CACHE_KEY_PREFIX}${PROJECT_REVISION}`;
 addFetchListener(function(event) {
   return caches.open(CACHE_NAME)
     .then(function(cache) {
-      return fetch(event.request, { mode: 'no-cors' })
+      return fetch(event.request, { mode: 'no-cors', credentials: 'same-origin' })
         .then(function(response) {
           cache.put(event.request, response.clone());
           return response;


### PR DESCRIPTION
Authorized API requests started failing using this addon. Allowing fetch to send credentials to `same-origin` solved this issue. I think it might sense to make this configurable, but I'm not sure how to do this.

By authorized in mean an `Authorization` HTTP header, but this should also address cases with cookies.