### PR TITLE
Fix escaping of URL regexs

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -24,6 +24,7 @@ module.exports = class Config extends Plugin {
     module += `export const VERSION = '${version}';\n`;
 
     if (patterns.length > 0) {
+      patterns = patterns.map((pattern) => pattern.replace(/\\/g, '\\\\'));
       module += `export const PATTERNS = ['${patterns.join("', '")}'];\n`;
     } else {
       module += 'export const PATTERNS = [];\n';

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,17 +1,11 @@
 import { PATTERNS, VERSION } from 'ember-service-worker-cache-fallback/service-worker/config';
 import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
+import { createUrlRegEx, urlMatchesAnyPattern } from 'ember-service-worker/service-worker/url-utils';
 
 const CACHE_KEY_PREFIX = 'esw-cache-fallback';
 const CACHE_NAME = `${CACHE_KEY_PREFIX}-${VERSION}`;
 
-const PATTERN_REGEX = PATTERNS.map((pattern) => {
-  let normalized = new URL(pattern, self.location).toString();
-  return new RegExp(`^${normalized}$`);
-});
-
-const MATCH = (key) => {
-  return !!PATTERN_REGEX.find((pattern) => pattern.test(key));
-};
+const PATTERN_REGEX = PATTERNS.map(createUrlRegEx);
 
 self.addEventListener('fetch', (event) => {
   let request = event.request;
@@ -19,7 +13,7 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  if (MATCH(request.url)) {
+  if (urlMatchesAnyPattern(request.url, PATTERN_REGEX)) {
     event.respondWith(
       caches.open(CACHE_NAME).then((cache) => {
         return fetch(request)
@@ -27,9 +21,7 @@ self.addEventListener('fetch', (event) => {
             cache.put(request, response.clone());
             return response;
           })
-          .catch((response) => {
-            return caches.match(event.request);
-          });
+          .catch(() => caches.match(event.request));
       })
     );
   }


### PR DESCRIPTION
Closes #11 .

## Changes proposed in this pull request

This uses the URL helpers introduced in https://github.com/DockYard/ember-service-worker/pull/64 to fix the escaped Regex chars issue, see #11.

Furthermore, the change in `lib/config.js` fixes the literal backslash character `\` in a pattern string being "swallowed" by inserting that pattern string into the service worker script without escaping it again (`\\`). Was that understandable what I just said?? 😬

Again, it needs https://github.com/DockYard/ember-service-worker/pull/64, so once that is released, should `esw` be added here as a `dependency` (maybe `peerDependency`?) with that new release version, to make sure the import will work?
