### PR TITLE
Add ignore option to disable cache for patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,14 @@ module.exports = function(defaults) {
       patterns: [
         '/api/v1/(.+)',
         'https://cdn.example.com/assets/fonts/(.+)',
-        'https://cdn.example.com/assets/images/((?!avatars/).+)'
+        'https://cdn.example.com/assets/images/(.+)'
       ],
+
+      // RegExp patterns to specifically disable cache for some urls.
+      ignore: [
+        '/api/v1/live-posts',
+        'https://cdn.example.com/assets/images/avatars(.+)'
+      ]
 
       // changing this version number will bust the cache
       version: '1'

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,21 +14,27 @@ module.exports = class Config extends Plugin {
     this.options = options;
   }
 
+  generatePatternExport(patterns, key){
+    if (patterns.length > 0) {
+      patterns = patterns.map((pattern) => pattern.replace(/\\/g, '\\\\'));
+      return `export const ${key} = ['${patterns.join("', '")}'];\n`;
+    } else {
+      return `export const ${key} = [];\n`;
+    }
+  }
+
   build() {
     let options = this.options;
     let version = options.version || '1';
     let patterns = options.patterns || [];
+    let ignore = options.ignore || [];
 
     let module = '';
 
     module += `export const VERSION = '${version}';\n`;
 
-    if (patterns.length > 0) {
-      patterns = patterns.map((pattern) => pattern.replace(/\\/g, '\\\\'));
-      module += `export const PATTERNS = ['${patterns.join("', '")}'];\n`;
-    } else {
-      module += 'export const PATTERNS = [];\n';
-    }
+    module += this.generatePatternExport(patterns, "PATTERNS")
+    module += this.generatePatternExport(ignore, "IGNORE_PATTERNS")
 
     fs.writeFileSync(path.join(this.outputPath, 'config.js'), module);
   }

--- a/service-worker/index.js
+++ b/service-worker/index.js
@@ -1,4 +1,4 @@
-import { PATTERNS, VERSION } from 'ember-service-worker-cache-fallback/service-worker/config';
+import { PATTERNS, IGNORE_PATTERNS, VERSION } from 'ember-service-worker-cache-fallback/service-worker/config';
 import cleanupCaches from 'ember-service-worker/service-worker/cleanup-caches';
 import { createUrlRegEx, urlMatchesAnyPattern } from 'ember-service-worker/service-worker/url-utils';
 
@@ -6,6 +6,7 @@ const CACHE_KEY_PREFIX = 'esw-cache-fallback';
 const CACHE_NAME = `${CACHE_KEY_PREFIX}-${VERSION}`;
 
 const PATTERN_REGEX = PATTERNS.map(createUrlRegEx);
+const IGNORE_PATTERN_REGEX = IGNORE_PATTERNS.map(createUrlRegEx);
 
 self.addEventListener('fetch', (event) => {
   let request = event.request;
@@ -13,7 +14,7 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  if (urlMatchesAnyPattern(request.url, PATTERN_REGEX)) {
+  if (urlMatchesAnyPattern(request.url, PATTERN_REGEX) && !urlMatchesAnyPattern(request.url, IGNORE_PATTERN_REGEX)) {
     event.respondWith(
       caches.open(CACHE_NAME).then((cache) => {
         return fetch(request)


### PR DESCRIPTION
## Changes proposed in this pull request
The addition of a `ignore` config option helps to keep a clearer overview of which urls are cached and wich are not.

For instance if we would like to cache our whole api but not `/api/posts` and `/api/cards` we can simply add those lines:
```javascript
patterns: [
  '/api/(.+)',
],
ignore: [
  '/api/posts',
  '/api/cards',
]
```

This is also possible in regex but is IMO way harder to maintain and less understandable:
```regex
\/api\/(((?!posts)(?!cards)).+)
```

